### PR TITLE
Incorporate SCS 3.x instances into calculation metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cf-trueup-plugin
 
+(some of the reporting data in this plugin has been wrong; fixing it to be accurate and extensible is a work in progress)
+
 cf-cli plugin showing memory consumption, application instances (AIs), and service instances (SIs) for each org and space you have permission to access.
 
 Reported SIs are for the "pivotal service suite", which as of writing this includes the following:
@@ -26,51 +28,36 @@ cf trueup-view -o firstorg -o secondorg [-o orgName...]
 ```
 
 ```txt
-Org north-area is consuming 38116 MB of 307200 MB.
-  Space development is consuming 1124 MB memory (0%) of org quota.
-    3 apps: 2 running 1 stopped
-    4 app instances: 3 running, 1 stopped
-    0 service instances of type Service Suite
-  Space staging is consuming 0 MB memory (0%) of org quota.
-    0 apps: 0 running 0 stopped
-    0 app instances: 0 running, 0 stopped
-    0 service instances of type Service Suite
-  Space production is consuming 0 MB memory (0%) of org quota.
-    1 apps: 0 running 1 stopped
-    1 app instances: 0 running, 1 stopped
-    0 service instances of type Service Suite
-  Space jigsheth is consuming 0 MB memory (0%) of org quota.
-    0 apps: 0 running 0 stopped
-    0 app instances: 0 running, 0 stopped
-    0 service instances of type Service Suite
-Org S1Pdemo14 is consuming 4096 MB of 102400 MB.
-  Space development is consuming 1024 MB memory (1%) of org quota.
-    2 apps: 1 running 1 stopped
-    2 app instances: 1 running, 1 stopped
-    1 service instances of type Service Suite
-  Space IoT-ConnectedCar-Emulator is consuming 1024 MB memory (1%) of org quota.
-    1 apps: 1 running 0 stopped
-    1 app instances: 1 running, 0 stopped
-    1 service instances of type Service Suite
-  Space sandbox is consuming 0 MB memory (0%) of org quota.
-    1 apps: 0 running 1 stopped
-    2 app instances: 0 running, 2 stopped
-    0 service instances of type Service Suite
-  Space auto-2 is consuming 0 MB memory (0%) of org quota.
-    1 apps: 0 running 1 stopped
-    3 app instances: 0 running, 3 stopped
-    0 service instances of type Service Suite
-  Space scdf-twitter-demo is consuming 0 MB memory (0%) of org quota.
-    7 apps: 0 running 7 stopped
-    7 app instances: 0 running, 7 stopped
-    0 service instances of type Service Suite
-  Space scs-demo is consuming 0 MB memory (0%) of org quota.
-    0 apps: 0 running 0 stopped
-    0 app instances: 0 running, 0 stopped
-    0 service instances of type Service Suite
-  Space scdf-twitter-demo-s1p-2018 is consuming 0 MB memory (0%) of org quota.
-    0 apps: 0 running 0 stopped
-    0 app instances: 0 running, 0 stopped
-    0 service instances of type Service Suite
-You have deployed 16 apps across 2 org(s), with a total of 20 app instances configured. You are currently running 4 apps with 5 app instances and using 2 service instances of type Service Suite.
+Org myorg is consuming 12864 MB of 20480 MB.
+        Space docs is consuming 4096 MB memory (20%) of org quota.
+                0 canonical app instances
+                4 billable app instances: 4 running, 0 stopped
+                0 unique app_guids: 0 running 0 stopped
+                0 service instances of type Service Suite (mysql, redis, rmq)
+        Space probots is consuming 6144 MB memory (30%) of org quota.
+                4 canonical app instances
+                4 billable app instances: 4 running, 0 stopped
+                3 unique app_guids: 3 running 0 stopped
+                0 service instances of type Service Suite (mysql, redis, rmq)
+        Space route53-sync is consuming 0 MB memory (0%) of org quota.
+                0 canonical app instances
+                0 billable app instances: 0 running, 0 stopped
+                0 unique app_guids: 0 running 0 stopped
+                0 service instances of type Service Suite (mysql, redis, rmq)
+        Space scratchpad is consuming 10816 MB memory (52%) of org quota.
+                10 canonical app instances
+                15 billable app instances: 13 running, 2 stopped
+                8 unique app_guids: 6 running 2 stopped
+                4 service instances of type Service Suite (mysql, redis, rmq)
+        Space splunk-firehose is consuming 1024 MB memory (5%) of org quota.
+                2 canonical app instances
+                2 billable app instances: 2 running, 0 stopped
+                1 unique app_guids: 1 running 0 stopped
+                0 service instances of type Service Suite (mysql, redis, rmq)
+        Space sso is consuming 0 MB memory (0%) of org quota.
+                0 canonical app instances
+                0 billable app instances: 0 running, 0 stopped
+                0 unique app_guids: 0 running 0 stopped
+                0 service instances of type Service Suite (mysql, redis, rmq)
+[WARNING: THIS REPORT SUMMARY IS MISLEADING AND INCORRECT. IT WILL BE FIXED SOON.] You have deployed 12 apps across 1 org(s), with a total of 25 app instances configured. You are currently running 10 apps with 23 app instances and using 4 service instances of type Service Suite.
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Reported SIs are for the "pivotal service suite", which as of writing this inclu
 - Redis (`p.redis`, `p-redis`)
 - MySQL (`p.mysql`, `p-mysql`)
 
+Services part of the "spring cloud config" (SCS) suite, although are "SIs" from the perspective of CF, are treated as AIs from the perspective of billing. The following service instances are _billed_ and currently in this tool _reported_ as running AIs:
+
+- Spring Cloud Config (`p-spring-cloud-config` in 2.x, `p.spring-cloud-config` in 3.x)
+- Service Registry (`p-service-registry` in 2.x, `p.service-registry` in 3.x)
+- Circuit Breaker (`p-circuit-breaker` in 2.x, non-existant in 3.x)
+
 ## usage
 
 ```sh

--- a/apihelper/apihelper.go
+++ b/apihelper/apihelper.go
@@ -253,6 +253,7 @@ func (api *APIHelper) GetSpaceAppsAndServices(summaryURL string) (Apps, Services
 								Label:       "p-rabbit",
 								ServicePlan: "p-dataflow-messaging",
 							})
+						// SCS 2.x
 					} else if strings.Contains(label, "p-circuit-breaker") || strings.Contains(label, "p-config-server") || strings.Contains(label, "p-service-registry") {
 						services = append(services,
 							Service{

--- a/apihelper/apihelper.go
+++ b/apihelper/apihelper.go
@@ -253,8 +253,12 @@ func (api *APIHelper) GetSpaceAppsAndServices(summaryURL string) (Apps, Services
 								Label:       "p-rabbit",
 								ServicePlan: "p-dataflow-messaging",
 							})
-						// SCS 2.x
-					} else if strings.Contains(label, "p-circuit-breaker") || strings.Contains(label, "p-config-server") || strings.Contains(label, "p-service-registry") {
+						// SCS 2.x + 3.x
+						// This is false advertising labeling, because "p-config-server" & "p-service-registry" are scs 2.x
+						// which use "p-spring-cloud-services" as their service broker, whereas
+						// "p.config-server" & p.service-registry" use "scs-service-broker" as their broker.
+						// For the sake of simplicity, we'll lump them both into "p-spring-cloud-services" for calculations
+					} else if strings.Contains(label, "circuit-breaker") || strings.Contains(label, "config-server") || strings.Contains(label, "service-registry") {
 						services = append(services,
 							Service{
 								Label:       "p-spring-cloud-services",

--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Name: "cf-trueup-plugin",
 		Version: plugin.VersionType{
 			Major: 2,
-			Minor: 5,
-			Build: 3,
+			Minor: 6,
+			Build: 0,
 		},
 		Commands: []plugin.Command{
 			{

--- a/models/models.go
+++ b/models/models.go
@@ -270,7 +270,7 @@ func (report *Report) String() string {
 		spaceBillableAppInstancesMsg  = "\t\t%d billable app instances: %d running, %d stopped\n"
 		spaceUniqueAppGuidsMsg        = "\t\t%d unique app_guids: %d running %d stopped\n"
 		spaceServiceSuiteMsg          = "\t\t%d service instances of type Service Suite (mysql, redis, rmq)\n"
-		reportSummaryMsg              = "You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
+		reportSummaryMsg              = "[WARNING: THIS REPORT SUMMARY IS MISLEADING AND INCORRECT. IT WILL BE FIXED SOON.] You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
 	)
 
 	chOrgStats := make(chan OrgStats, len(report.Orgs))

--- a/models/models.go
+++ b/models/models.go
@@ -258,14 +258,12 @@ func (report *Report) String() string {
 	totalServiceInstances := 0
 
 	const (
-		orgOverviewMsg   = "Org %s is consuming %d MB of %d MB.\n"
-		spaceOverviewMsg = "\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n"
-		// Notice that "apps" here refers to unique app_guids, which doesn't calculate _instances_ of the app
-		// So even if you have 3 instances of "myapp" running, "apps" is still reported as "1"
-		spaceAppsMsg         = "\t\t%d apps: %d running %d stopped\n"
-		spaceAppInstancesMsg = "\t\t%d app instances: %d running, %d stopped\n"
-		spaceServiceSuiteMsg = "\t\t%d service instances of type Service Suite\n"
-		reportSummaryMsg     = "You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
+		orgOverviewMsg               = "Org %s is consuming %d MB of %d MB.\n"
+		spaceOverviewMsg             = "\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n"
+		spaceUniqueAppGuidsMsg       = "\t\t%d unique app_guids: %d running %d stopped\n"
+		spaceBillableAppInstancesMsg = "\t\t%d billable app instances: %d running, %d stopped\n"
+		spaceServiceSuiteMsg         = "\t\t%d service instances of type Service Suite (mysql, redis, rmq)\n"
+		reportSummaryMsg             = "You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
 	)
 
 	chOrgStats := make(chan OrgStats, len(report.Orgs))
@@ -284,10 +282,10 @@ func (report *Report) String() string {
 				response.WriteString(fmt.Sprintf(spaceOverviewMsg, spaceState.Name, spaceState.ConsumedMemory, spaceMemoryConsumedPercentage))
 			}
 
-			response.WriteString(fmt.Sprintf(spaceAppsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
+			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
 
 			response.WriteString(
-				fmt.Sprintf(spaceAppInstancesMsg, spaceState.DeployedAppInstancesCount, spaceState.RunningAppInstancesCount, spaceState.StoppedAppInstancesCount))
+				fmt.Sprintf(spaceBillableAppInstancesMsg, spaceState.DeployedAppInstancesCount, spaceState.RunningAppInstancesCount, spaceState.StoppedAppInstancesCount))
 
 			response.WriteString(fmt.Sprintf(spaceServiceSuiteMsg, spaceState.ServicesCount))
 

--- a/models/models.go
+++ b/models/models.go
@@ -258,12 +258,13 @@ func (report *Report) String() string {
 	totalServiceInstances := 0
 
 	const (
-		orgOverviewMsg               = "Org %s is consuming %d MB of %d MB.\n"
-		spaceOverviewMsg             = "\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n"
-		spaceUniqueAppGuidsMsg       = "\t\t%d unique app_guids: %d running %d stopped\n"
-		spaceBillableAppInstancesMsg = "\t\t%d billable app instances: %d running, %d stopped\n"
-		spaceServiceSuiteMsg         = "\t\t%d service instances of type Service Suite (mysql, redis, rmq)\n"
-		reportSummaryMsg             = "You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
+		orgOverviewMsg                = "Org %s is consuming %d MB of %d MB.\n"
+		spaceOverviewMsg              = "\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n"
+		spaceCanonicalAppInstancesMsg = "\t\t%d canonical app instances: %d running %d stopped\n"
+		spaceUniqueAppGuidsMsg        = "\t\t%d unique app_guids: %d running %d stopped\n"
+		spaceBillableAppInstancesMsg  = "\t\t%d billable app instances: %d running, %d stopped\n"
+		spaceServiceSuiteMsg          = "\t\t%d service instances of type Service Suite (mysql, redis, rmq)\n"
+		reportSummaryMsg              = "You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
 	)
 
 	chOrgStats := make(chan OrgStats, len(report.Orgs))
@@ -281,6 +282,8 @@ func (report *Report) String() string {
 				spaceMemoryConsumedPercentage := (100 * spaceState.ConsumedMemory / orgStats.MemoryQuota)
 				response.WriteString(fmt.Sprintf(spaceOverviewMsg, spaceState.Name, spaceState.ConsumedMemory, spaceMemoryConsumedPercentage))
 			}
+
+			response.WriteString(fmt.Sprintf(spaceCanonicalAppInstancesMsg, nil, nil, nil))
 
 			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
 

--- a/models/models.go
+++ b/models/models.go
@@ -266,9 +266,9 @@ func (report *Report) String() string {
 	const (
 		orgOverviewMsg                = "Org %s is consuming %d MB of %d MB.\n"
 		spaceOverviewMsg              = "\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n"
-		spaceCanonicalAppInstancesMsg = "\t\t%d canonical app instances:\n" // %d running %d stopped\n"
-		spaceUniqueAppGuidsMsg        = "\t\t%d unique app_guids: %d running %d stopped\n"
+		spaceCanonicalAppInstancesMsg = "\t\t%d canonical app instances\n"
 		spaceBillableAppInstancesMsg  = "\t\t%d billable app instances: %d running, %d stopped\n"
+		spaceUniqueAppGuidsMsg        = "\t\t%d unique app_guids: %d running %d stopped\n"
 		spaceServiceSuiteMsg          = "\t\t%d service instances of type Service Suite (mysql, redis, rmq)\n"
 		reportSummaryMsg              = "You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
 	)
@@ -291,10 +291,10 @@ func (report *Report) String() string {
 
 			response.WriteString(fmt.Sprintf(spaceCanonicalAppInstancesMsg, spaceState.CanonicalAppInstancesCount))
 
-			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
-
 			response.WriteString(
 				fmt.Sprintf(spaceBillableAppInstancesMsg, spaceState.DeployedAppInstancesCount, spaceState.RunningAppInstancesCount, spaceState.StoppedAppInstancesCount))
+
+			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
 
 			response.WriteString(fmt.Sprintf(spaceServiceSuiteMsg, spaceState.ServicesCount))
 

--- a/models/models.go
+++ b/models/models.go
@@ -274,6 +274,7 @@ func (report *Report) String() string {
 	for orgStats := range chOrgStats {
 		response.WriteString(fmt.Sprintf(orgOverviewMsg, orgStats.Name, orgStats.MemoryUsage, orgStats.MemoryQuota))
 		chSpaceStats := make(chan SpaceStats, len(orgStats.Spaces))
+		// TODO dynamic filtering?
 		go orgStats.Spaces.Stats(chSpaceStats, orgStats.Name == "p-spring-cloud-services")
 		for spaceState := range chSpaceStats {
 

--- a/scratchpad/generic-labeling.md
+++ b/scratchpad/generic-labeling.md
@@ -1,0 +1,25 @@
+# generic-labeling
+
+instead of putting the rules directly in the code, can they be externalized?
+
+e.g., a way to define...
+
+- "any `user-provided-services` should be counted as an AI"
+- "any service which comes from `<some-broker>` should be reported as an AI"
+- "anything which has this metadata information should be treated as xyzabc"
+
+overthinking example:
+
+```yml
+rules:
+- id: someruleid
+  category: {services, apps}
+  match: # all optional matching
+  - service: servicename
+    plan: serviceplan
+    service_instance: serviceinstanceregex
+    broker: servicebrokername
+  report_as:
+    category: {services, apps, none}
+    # would still need some way to have SCDF report as three different apps
+```

--- a/scratchpad/generic-labeling.md
+++ b/scratchpad/generic-labeling.md
@@ -7,6 +7,11 @@ e.g., a way to define...
 - "any `user-provided-services` should be counted as an AI"
 - "any service which comes from `<some-broker>` should be reported as an AI"
 - "anything which has this metadata information should be treated as xyzabc"
+- orgs to be filtered out of _all_ searches, e.g. like how in models/report there's this line:
+
+```go
+go orgStats.Spaces.Stats(chSpaceStats, orgStats.Name == "p-spring-cloud-services")
+```
 
 overthinking example:
 

--- a/scratchpad/notes.md
+++ b/scratchpad/notes.md
@@ -119,3 +119,34 @@ In order to properly set _quotas_ using this data, I need to know:
 - How many AIs are _actually_ applications? I don't care about individual "standalone" applications
 - How many SIs are _actually_ SIs?
 - To what extent do overages need to be accounted for?
+
+## proposed revisualization
+
+Alright, let's try a new mockup of this data
+
+We've established that...
+
+```txt
+Org x is consuming 12864 MB of 20480 MB. <-- numbers are fine
+        Space scratchpad is consuming 8768 MB memory (42%) of org quota.
+                8 apps: 6 running 2 stopped <-- don't really need to know
+                13 app instances: 11 running, 2 stopped <-- misleading
+                4 service instances of type Service Suite <-- inaccurate?
+```
+
+so how about...
+
+```txt
+Org x is consuming 12864 MB of 20480 MB.
+  Space scratchpad is consuming 8768 MB memory (42%) of org quota.
+    billable:
+      15 AIs
+      4 SIs
+    usable:
+      10 AIs
+        8 running
+        2 stopped
+      9 SIs
+        5 billed as AIs
+        4 others
+```

--- a/scratchpad/notes.md
+++ b/scratchpad/notes.md
@@ -102,6 +102,7 @@ The second line, `13 app instances: 11 running, 2 stopped`, is bizzare. There ar
 Why should it report like that, though? Let's try something different. My boss wants to know:
 
 - _billable_ app instances
+  - _billable_ max concurrent(?)
 - _billable_ service instances
 
 In order to get that data, I need to know:
@@ -112,3 +113,9 @@ In order to get that data, I need to know:
 - SIs that aren't _actually_ services, but are instead being _counted_ as AIs
 - SIs that are composed of _multiple_ other AIs and SIs, e.g. SCDF
 - How _user provided services_ should be counted
+
+In order to properly set _quotas_ using this data, I need to know:
+
+- How many AIs are _actually_ applications? I don't care about individual "standalone" applications
+- How many SIs are _actually_ SIs?
+- To what extent do overages need to be accounted for?

--- a/scratchpad/notes.md
+++ b/scratchpad/notes.md
@@ -92,3 +92,23 @@ We should really only care about 'scratchpad'
 13 app instances: 11 running, 2 stopped
 4 service instances of type Service Suite
 ```
+
+## what we can deduce
+
+The first line, `8 apps: 6 running 2 stopped`, has nothing to do with app instances at all.
+
+The second line, `13 app instances: 11 running, 2 stopped`, is bizzare. There are `10` app_instances possible if you add up the results from `cf apps`. So it's definitely adding up something extra.
+
+Why should it report like that, though? Let's try something different. My boss wants to know:
+
+- _billable_ app instances
+- _billable_ service instances
+
+In order to get that data, I need to know:
+
+- AIs that are _actually_ applications
+- AIs that aren't _actually_ applications, but are instead _counted_ as AIs (e.g. SCS, etc., although getting a straight answer on what counts as an AI/SI is surprisingly annoying)
+- SIs that are _actually_ service instances
+- SIs that aren't _actually_ services, but are instead being _counted_ as AIs
+- SIs that are composed of _multiple_ other AIs and SIs, e.g. SCDF
+- How _user provided services_ should be counted

--- a/scratchpad/notes.md
+++ b/scratchpad/notes.md
@@ -31,12 +31,12 @@ rmq-standard
 small-redis
 tiny-sql
 
-# scs services, x5
-config
-config-server
-registry
-scs-reg
-scs-wow
+# scs services, x5 total (x3 scs2, x2 scs3)
+config (p-config-server, p-spring-cloud-services)
+config-server (p-config-server, p-spring-cloud-services)
+registry (p-service-registry, p-spring-cloud-services)
+scs-reg (p.service-registry, scs-service-broker)
+scs-wow (p.config-server, scs-service-broker)
 ```
 
 ```txt

--- a/scratchpad/notes.md
+++ b/scratchpad/notes.md
@@ -1,0 +1,94 @@
+# notes
+
+```txt
+cf services
+
+name                  service              plan            bound apps                                     last operation     broker                    upgrade available
+autoscaler            app-autoscaler       standard                                                       create succeeded   app-autoscaler
+config                p-config-server      standard        cfenv-demo                                     create succeeded   p-spring-cloud-services
+config-server         p-config-server      standard        gwx-spring-boot-example-basic                  update succeeded   p-spring-cloud-services
+identity              p-identity           uaa             cfenv-demo                                     create succeeded   identity-service-broker
+metrics-forwarder     metrics-forwarder    unlimited                                                      create succeeded   metrics-forwarder
+metrics-forwarder-1   metrics-forwarder    unlimited       cf-sample-app-nodejs, cfenv-demo, nodejs-web   create succeeded   metrics-forwarder
+newrelic              user-provided                        gwx-spring-boot-example-basic
+registry              p-service-registry   standard                                                       create succeeded   p-spring-cloud-services
+rmq-clustered         p.rabbitmq           clustered-3.7                                                  create succeeded   rabbitmq-odb
+rmq-standard          p-rabbitmq           standard                                                       create succeeded   p-rabbitmq
+s3                    aws-s3               standard                                                       create succeeded   aws-services-broker
+scheduler             scheduler-for-pcf    standard        nodejs-web                                     create succeeded   scheduler-for-pcf
+scs-reg               p.service-registry   standard                                                       create succeeded   scs-service-broker
+scs-wow               p.config-server      standard        nodejs-web                                     update succeeded   scs-service-broker
+small-redis           p.redis              cache-small                                                    create succeeded   redis-odb
+tiny-sql              p.mysql              db-small        cfenv-demo                                     update succeeded   dedicated-mysql-broker
+```
+
+services that should count:
+
+```txt
+# data services, x4
+rmq-clustered
+rmq-standard
+small-redis
+tiny-sql
+
+# scs services, x5
+config
+config-server
+registry
+scs-reg
+scs-wow
+```
+
+```txt
+cf apps
+
+cf-sample-app-nodejs            started           1/1         512M     1G
+cfenv-demo                      started           1/1         1G       256M
+gwx-asp-net-core-app-basic      started           1/1         1G       1G
+gwx-spring-boot-example-basic   started           1/1         1G       512M
+gwx-spring-boot-sample-ui       stopped           0/1         2G       512M
+hammerdb-test                   stopped           0/1         1G       1G
+nodejs-web                      started           2/2         32M      1G
+push-test-webhook-switchboard   started           2/2         1G       1G
+```
+
+then let's check it against what's reported
+
+```txt
+cf trueup-view -o x
+
+Org x is consuming 12864 MB of 20480 MB.
+        Space docs is consuming 2048 MB memory (10%) of org quota.
+                0 apps: 0 running 0 stopped
+                2 app instances: 2 running, 0 stopped
+                0 service instances of type Service Suite
+        Space probots is consuming 6144 MB memory (30%) of org quota.
+                3 apps: 3 running 0 stopped
+                4 app instances: 4 running, 0 stopped
+                0 service instances of type Service Suite
+        Space route53-sync is consuming 0 MB memory (0%) of org quota.
+                0 apps: 0 running 0 stopped
+                0 app instances: 0 running, 0 stopped
+                0 service instances of type Service Suite
+        Space scratchpad is consuming 8768 MB memory (42%) of org quota.
+                8 apps: 6 running 2 stopped
+                13 app instances: 11 running, 2 stopped
+                4 service instances of type Service Suite
+        Space splunk-firehose is consuming 1024 MB memory (5%) of org quota.
+                1 apps: 1 running 0 stopped
+                2 app instances: 2 running, 0 stopped
+                0 service instances of type Service Suite
+        Space sso is consuming 0 MB memory (0%) of org quota.
+                0 apps: 0 running 0 stopped
+                0 app instances: 0 running, 0 stopped
+                0 service instances of type Service Suite
+You have deployed 12 apps across 1 org(s), with a total of 21 app instances configured. You are currently running 10 apps with 19 app instances and using 4 service instances of type Service Suite.
+```
+
+We should really only care about 'scratchpad'
+
+```txt
+8 apps: 6 running 2 stopped
+13 app instances: 11 running, 2 stopped
+4 service instances of type Service Suite
+```

--- a/scratchpad/notes.md
+++ b/scratchpad/notes.md
@@ -150,3 +150,50 @@ Org x is consuming 12864 MB of 20480 MB.
         5 billed as AIs
         4 others
 ```
+
+perhaps a configurable detailed view?
+
+```txt
+Org x is consuming 12864 MB of 20480 MB.
+  Space scratchpad is consuming 8768 MB memory (42%) of org quota.
+    billable:
+      AIs: 15 <-- let's move these to be right-side oriented
+        applications: 10
+          cf-sample-app-nodejs            started           1/1
+          cfenv-demo                      started           1/1
+          gwx-asp-net-core-app-basic      started           1/1
+          gwx-spring-boot-example-basic   started           1/1
+          gwx-spring-boot-sample-ui       stopped           0/1
+          hammerdb-test                   stopped           0/1
+          nodejs-web                      started           2/2
+          push-test-webhook-switchboard   started           2/2
+        services: 5
+          config [maybe more details?]
+          config-server
+          registry
+          scs-reg
+          scs-wow
+      SIs: 4
+        services: 4
+          rmq-clustered [maybe more details off to the side?]
+          rmq-standard
+          small-redis
+          tiny-sql
+    usable:
+      AIs: 10
+        running: 8
+        stopped: 2
+      SIs: 9
+        billed as AIs: 5
+        others: 4
+```
+
+todo: how does this work with user-provided services? how does this work with "multi-service-services" like SCDF?
+
+## what are the official rules
+
+Need to talk to someone from Pivotal about this. It could either be embodied in the code itself directly, or later could evaluate a more genericized rules system. Shouldn't be anything extravogent.
+
+## to what extent do the API endpoints used really matter
+
+Are there fundamental differences between how v2 and v3 will report things? etc.

--- a/scratchpad/notes2.md
+++ b/scratchpad/notes2.md
@@ -5,30 +5,19 @@ wow what an incredible file name, right?
 Before including scs 3.x labels:
 
 ```txt
-Org x is consuming 12864 MB of 20480 MB.
-        Space docs is consuming 2048 MB memory (10%) of org quota.
-                0 apps: 0 running 0 stopped
-                2 app instances: 2 running, 0 stopped
-                0 service instances of type Service Suite
-        Space probots is consuming 6144 MB memory (30%) of org quota.
-                3 apps: 3 running 0 stopped
-                4 app instances: 4 running, 0 stopped
-                0 service instances of type Service Suite
-        Space route53-sync is consuming 0 MB memory (0%) of org quota.
-                0 apps: 0 running 0 stopped
-                0 app instances: 0 running, 0 stopped
-                0 service instances of type Service Suite
-        Space scratchpad is consuming 8768 MB memory (42%) of org quota.
-                8 apps: 6 running 2 stopped
-                13 app instances: 11 running, 2 stopped
-                4 service instances of type Service Suite
-        Space splunk-firehose is consuming 1024 MB memory (5%) of org quota.
-                1 apps: 1 running 0 stopped
-                2 app instances: 2 running, 0 stopped
-                0 service instances of type Service Suite
-        Space sso is consuming 0 MB memory (0%) of org quota.
-                0 apps: 0 running 0 stopped
-                0 app instances: 0 running, 0 stopped
-                0 service instances of type Service Suite
-You have deployed 12 apps across 1 org(s), with a total of 21 app instances configured. You are currently running 10 apps with 19 app instances and using 4 service instances of type Service Suite.
+Space scratchpad is consuming 8768 MB memory (42%) of org quota.
+        8 apps: 6 running 2 stopped
+        13 app instances: 11 running, 2 stopped
+        4 service instances of type Service Suite
 ```
+
+after changing `string.Contains` logic:
+
+```txt
+Space scratchpad is consuming 10816 MB memory (52%) of org quota.
+        8 apps: 6 running 2 stopped
+        15 app instances: 13 running, 2 stopped
+        4 service instances of type Service Suite
+```
+
+So we know the two scs-service-broker's got added.

--- a/scratchpad/notes2.md
+++ b/scratchpad/notes2.md
@@ -1,0 +1,34 @@
+# notes2
+
+wow what an incredible file name, right?
+
+Before including scs 3.x labels:
+
+```txt
+Org x is consuming 12864 MB of 20480 MB.
+        Space docs is consuming 2048 MB memory (10%) of org quota.
+                0 apps: 0 running 0 stopped
+                2 app instances: 2 running, 0 stopped
+                0 service instances of type Service Suite
+        Space probots is consuming 6144 MB memory (30%) of org quota.
+                3 apps: 3 running 0 stopped
+                4 app instances: 4 running, 0 stopped
+                0 service instances of type Service Suite
+        Space route53-sync is consuming 0 MB memory (0%) of org quota.
+                0 apps: 0 running 0 stopped
+                0 app instances: 0 running, 0 stopped
+                0 service instances of type Service Suite
+        Space scratchpad is consuming 8768 MB memory (42%) of org quota.
+                8 apps: 6 running 2 stopped
+                13 app instances: 11 running, 2 stopped
+                4 service instances of type Service Suite
+        Space splunk-firehose is consuming 1024 MB memory (5%) of org quota.
+                1 apps: 1 running 0 stopped
+                2 app instances: 2 running, 0 stopped
+                0 service instances of type Service Suite
+        Space sso is consuming 0 MB memory (0%) of org quota.
+                0 apps: 0 running 0 stopped
+                0 app instances: 0 running, 0 stopped
+                0 service instances of type Service Suite
+You have deployed 12 apps across 1 org(s), with a total of 21 app instances configured. You are currently running 10 apps with 19 app instances and using 4 service instances of type Service Suite.
+```

--- a/scratchpad/terminology.md
+++ b/scratchpad/terminology.md
@@ -1,0 +1,73 @@
+# terminology
+
+will need to make sure I'm using official terminology in the future, but let me get this straight at least for myself:
+
+## lApps
+
+"length of apps in a space" == unique app guids, including stopped ones. Does NOT capture the app _instances_ of the app guids
+
+so if you had this from `cf apps`:
+
+```txt
+hammerdb-test                   stopped           0/1
+nodejs-web                      started           2/2
+push-test-webhook-switchboard   started           2/2
+```
+
+that would be 3 apps, even though one of them is `stopped`
+
+## rApps
+
+"running apps" == unique app guids, but however many of them are actually running
+
+so this:
+
+```txt
+hammerdb-test                   stopped           0/1
+nodejs-web                      started           2/2
+push-test-webhook-switchboard   started           2/2
+```
+
+would be 2
+
+## InstancesCount
+
+"total number of app AIs" == unique app guids multiplied by however many instances they have declared
+
+started/stopped doesn't matter
+
+```txt
+hammerdb-test                   stopped           0/1
+nodejs-web                      started           2/2
+push-test-webhook-switchboard   started           2/2
+```
+
+this would be...
+
+```txt
+hammerdb-test => 1
+nodejs-web => 2
+push-test-webhook-switchboard => 2
+```
+
+total of 5
+
+## lAIs
+
+here's where things get weird. lAIs is "length of total number of AIs". But first you have to ask, _what is an AI?_ `p-spring-cloud-config` is an SI from CF's perspective, but gets _billed_ as an AI. Currently, "billable AIs" like SCS or SCDF are lumped into lAIs and reported as a "running app instance"
+
+I propose we change this.
+
+We need to distinguish between "billable AIs" and "real AIs", or something to that effect. Maybe call it "cf AIs"? That's lame, dont' call it that.
+
+... `cannonicalAI`?
+
+(bAIs for billableAIs?)
+
+How about an AI is an app within an org/space, and then a "billableAI" is a superset of AIs and _anything else_, like SIs, etc.?
+
+Let me just try `cAIs` == cannonical AI, which is what cf would report as an application running within the org/space
+
+## rAIs
+
+"running AIs", which are a combination of "running cAIs and bAIs"... e.g., SCS, SCDF, etc.


### PR DESCRIPTION
Scratchpad notes proposing new reporting and visualization
Scratchpad notes proposing generic labeling reporting mechanism
Bump to 2.6.0 since we're incorporating SCS3.x instances into the mix