### PR TITLE
Cleanup internal API usage on models

### DIFF
--- a/apihelper/apihelper.go
+++ b/apihelper/apihelper.go
@@ -203,6 +203,8 @@ func (api *APIHelper) GetOrgSpaces(spacesURL string) (Spaces, error) {
 
 // GetSpaceAppsAndServices returns the apps and the services in a space
 //
+// In reality though, it's just getting the SpaceSummary, right?
+//
 // This function is problematic because the services it returns are a limited subset
 // of the actual services found within a space. We don't want to make those decisions
 // here, we'll want to store off the data and make decisions on _how_ and _what_ to render

--- a/apihelper/apihelper.go
+++ b/apihelper/apihelper.go
@@ -233,6 +233,8 @@ func (api *APIHelper) GetSpaceAppsAndServices(summaryURL string) (Apps, Services
 	if _, ok := summaryJSON["services"]; ok {
 		for _, s := range summaryJSON["services"].([]interface{}) {
 			theService := s.(map[string]interface{})
+			// TODO I believe us filtering on service plan existing means that
+			// user-provided services won't be included in this
 			if _, servicePlanExist := theService["service_plan"]; servicePlanExist {
 				servicePlan := theService["service_plan"].(map[string]interface{})
 				if _, serviceExist := servicePlan["service"]; serviceExist {
@@ -250,49 +252,6 @@ func (api *APIHelper) GetSpaceAppsAndServices(summaryURL string) (Apps, Services
 							Label:       label,
 							ServicePlan: servicePlan["name"].(string),
 						})
-					// if strings.EqualFold(label, "p-dataflow") {
-					// 	services = append(services,
-					// 		Service{
-					// 			Label:       "p-dataflow-servers",
-					// 			ServicePlan: servicePlan["name"].(string),
-					// 		})
-					// }
-					// if strings.EqualFold(label, "p-dataflow-analytics") {
-					// 	services = append(services,
-					// 		Service{
-					// 			Label:       "p-redis",
-					// 			ServicePlan: "p-dataflow-analytics",
-					// 		})
-					// } else if strings.EqualFold(label, "p-dataflow-relational") {
-					// 	services = append(services,
-					// 		Service{
-					// 			Label:       "p-mysql",
-					// 			ServicePlan: "p-dataflow-relational",
-					// 		})
-					// } else if strings.EqualFold(label, "p-dataflow-messaging") {
-					// 	services = append(services,
-					// 		Service{
-					// 			Label:       "p-rabbit",
-					// 			ServicePlan: "p-dataflow-messaging",
-					// 		})
-					// 	// SCS 2.x + 3.x
-					// 	// This is false advertising labeling, because "p-config-server" & "p-service-registry" are scs 2.x
-					// 	// which use "p-spring-cloud-services" as their service broker, whereas
-					// 	// "p.config-server" & p.service-registry" use "scs-service-broker" as their broker.
-					// 	// For the sake of simplicity, we'll lump them both into "p-spring-cloud-services" for calculations
-					// } else if strings.Contains(label, "circuit-breaker") || strings.Contains(label, "config-server") || strings.Contains(label, "service-registry") {
-					// 	services = append(services,
-					// 		Service{
-					// 			Label:       "p-spring-cloud-services",
-					// 			ServicePlan: label,
-					// 		})
-					// } else if strings.Contains(label, "rabbit") || strings.Contains(label, "redis") || strings.Contains(label, "mysql") {
-					// 	services = append(services,
-					// 		Service{
-					// 			Label:       label,
-					// 			ServicePlan: servicePlan["name"].(string),
-					// 		})
-					// }
 				}
 			}
 		}

--- a/apihelper/apihelper.go
+++ b/apihelper/apihelper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/aegershman/cf-trueup-plugin/cfcurl"
 	"github.com/cloudfoundry/cli/plugin"
@@ -239,49 +238,61 @@ func (api *APIHelper) GetSpaceAppsAndServices(summaryURL string) (Apps, Services
 				if _, serviceExist := servicePlan["service"]; serviceExist {
 					service := servicePlan["service"].(map[string]interface{})
 					label := service["label"].(string)
-					if strings.EqualFold(label, "p-dataflow") {
-						services = append(services,
-							Service{
-								Label:       "p-dataflow-servers",
-								ServicePlan: servicePlan["name"].(string),
-							})
-					}
-					if strings.EqualFold(label, "p-dataflow-analytics") {
-						services = append(services,
-							Service{
-								Label:       "p-redis",
-								ServicePlan: "p-dataflow-analytics",
-							})
-					} else if strings.EqualFold(label, "p-dataflow-relational") {
-						services = append(services,
-							Service{
-								Label:       "p-mysql",
-								ServicePlan: "p-dataflow-relational",
-							})
-					} else if strings.EqualFold(label, "p-dataflow-messaging") {
-						services = append(services,
-							Service{
-								Label:       "p-rabbit",
-								ServicePlan: "p-dataflow-messaging",
-							})
-						// SCS 2.x + 3.x
-						// This is false advertising labeling, because "p-config-server" & "p-service-registry" are scs 2.x
-						// which use "p-spring-cloud-services" as their service broker, whereas
-						// "p.config-server" & p.service-registry" use "scs-service-broker" as their broker.
-						// For the sake of simplicity, we'll lump them both into "p-spring-cloud-services" for calculations
-					} else if strings.Contains(label, "circuit-breaker") || strings.Contains(label, "config-server") || strings.Contains(label, "service-registry") {
-						services = append(services,
-							Service{
-								Label:       "p-spring-cloud-services",
-								ServicePlan: label,
-							})
-					} else if strings.Contains(label, "rabbit") || strings.Contains(label, "redis") || strings.Contains(label, "mysql") {
-						services = append(services,
-							Service{
-								Label:       label,
-								ServicePlan: servicePlan["name"].(string),
-							})
-					}
+					// Don't do filtering here: filter in a different location.
+					// Here we just want to aggregate the data into something we
+					// can use in a presenter somewhere else.
+					//
+					// Also we shouldn't do premature filtering here
+					// and then act as though the only services that exist in
+					// a space are the ones that have passed the filter
+					services = append(services,
+						Service{
+							Label:       label,
+							ServicePlan: servicePlan["name"].(string),
+						})
+					// if strings.EqualFold(label, "p-dataflow") {
+					// 	services = append(services,
+					// 		Service{
+					// 			Label:       "p-dataflow-servers",
+					// 			ServicePlan: servicePlan["name"].(string),
+					// 		})
+					// }
+					// if strings.EqualFold(label, "p-dataflow-analytics") {
+					// 	services = append(services,
+					// 		Service{
+					// 			Label:       "p-redis",
+					// 			ServicePlan: "p-dataflow-analytics",
+					// 		})
+					// } else if strings.EqualFold(label, "p-dataflow-relational") {
+					// 	services = append(services,
+					// 		Service{
+					// 			Label:       "p-mysql",
+					// 			ServicePlan: "p-dataflow-relational",
+					// 		})
+					// } else if strings.EqualFold(label, "p-dataflow-messaging") {
+					// 	services = append(services,
+					// 		Service{
+					// 			Label:       "p-rabbit",
+					// 			ServicePlan: "p-dataflow-messaging",
+					// 		})
+					// 	// SCS 2.x + 3.x
+					// 	// This is false advertising labeling, because "p-config-server" & "p-service-registry" are scs 2.x
+					// 	// which use "p-spring-cloud-services" as their service broker, whereas
+					// 	// "p.config-server" & p.service-registry" use "scs-service-broker" as their broker.
+					// 	// For the sake of simplicity, we'll lump them both into "p-spring-cloud-services" for calculations
+					// } else if strings.Contains(label, "circuit-breaker") || strings.Contains(label, "config-server") || strings.Contains(label, "service-registry") {
+					// 	services = append(services,
+					// 		Service{
+					// 			Label:       "p-spring-cloud-services",
+					// 			ServicePlan: label,
+					// 		})
+					// } else if strings.Contains(label, "rabbit") || strings.Contains(label, "redis") || strings.Contains(label, "mysql") {
+					// 	services = append(services,
+					// 		Service{
+					// 			Label:       label,
+					// 			ServicePlan: servicePlan["name"].(string),
+					// 		})
+					// }
 				}
 			}
 		}

--- a/models/models.go
+++ b/models/models.go
@@ -264,9 +264,9 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 	for _, space := range spaces {
 		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
 		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
-		lApps := space.AppsCount()
-		rApps := space.RunningAppsCount()
-		sApps := lApps - rApps
+		totalUniqueApps := space.AppsCount()
+		runningUniqueApps := space.RunningAppsCount()
+		stoppedUniqueApps := totalUniqueApps - runningUniqueApps
 		// "canonical" appInstances are what we can use for setting a quota
 		canonicalAppInstances := space.AppInstancesCount()
 		// "lAIs" in this context is really "billableAIs", but I don't want to mess
@@ -284,9 +284,9 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		}
 		c <- SpaceStats{
 			Name:                       space.Name,
-			DeployedAppsCount:          lApps,
-			RunningAppsCount:           rApps,
-			StoppedAppsCount:           sApps,
+			DeployedAppsCount:          totalUniqueApps,
+			RunningAppsCount:           runningUniqueApps,
+			StoppedAppsCount:           stoppedUniqueApps,
 			CanonicalAppInstancesCount: canonicalAppInstances,
 			DeployedAppInstancesCount:  lAIs,
 			RunningAppInstancesCount:   rAIs,

--- a/models/models.go
+++ b/models/models.go
@@ -86,7 +86,7 @@ type Report struct {
 func (org *Org) InstancesCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
-		instancesCount += space.InstancesCount()
+		instancesCount += space.AppInstancesCount()
 		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
 		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
 		instancesCount += SCSCount + (SCDFCount * 3)
@@ -165,7 +165,7 @@ func (space *Space) RunningAppsCount() int {
 	return runningAppsCount
 }
 
-// InstancesCount returns the count of declared canonical app instances
+// AppInstancesCount returns the count of declared canonical app instances
 // regardless of start/stop state
 //
 // for example, if you have the following result from `cf apps`:
@@ -175,12 +175,12 @@ func (space *Space) RunningAppsCount() int {
 // push-test-webhook-switchboard   started           2/2
 //
 // then you'd have "5 app instances"
-func (space *Space) InstancesCount() int {
-	instancesCount := 0
+func (space *Space) AppInstancesCount() int {
+	appInstancesCount := 0
 	for _, app := range space.Apps {
-		instancesCount += int(app.Desire)
+		appInstancesCount += int(app.Desire)
 	}
-	return instancesCount
+	return appInstancesCount
 }
 
 // RunningAppInstancesCount returns the count of declared canonical app instances
@@ -235,10 +235,10 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		rApps := space.RunningAppsCount()
 		sApps := lApps - rApps
 		// "canonical" appInstances are what we can use for setting a quota
-		canonicalAppInstances := space.InstancesCount()
+		canonicalAppInstances := space.AppInstancesCount()
 		// "lAIs" in this context is really "billableAIs", but I don't want to mess
 		// with the existing logic before getting a chance to rework this
-		lAIs := space.InstancesCount()
+		lAIs := space.AppInstancesCount()
 		lAIs += (SCSCount + (SCDFCount * 3))
 		rAIs := space.RunningAppInstancesCount()
 		rAIs += (SCSCount + (SCDFCount * 3))

--- a/models/models.go
+++ b/models/models.go
@@ -87,8 +87,8 @@ func (org *Org) InstancesCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
 		instancesCount += space.InstancesCount()
-		SCSCount := space.ServiceInstancesCount("p-spring-cloud-services")
-		SCDFCount := space.ServiceInstancesCount("p-dataflow-servers")
+		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
+		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
 		instancesCount += SCSCount + (SCDFCount * 3)
 	}
 	return instancesCount
@@ -108,8 +108,8 @@ func (org *Org) RunningInstancesCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
 		instancesCount += space.RunningInstancesCount()
-		SCSCount := space.ServiceInstancesCount("p-spring-cloud-services")
-		SCDFCount := space.ServiceInstancesCount("p-dataflow-servers")
+		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
+		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
 		instancesCount += SCSCount + (SCDFCount * 3)
 	}
 	return instancesCount
@@ -129,8 +129,8 @@ func (org *Org) ServicesCount() int {
 	servicesCount := 0
 	for _, space := range org.Spaces {
 		servicesCount += len(space.Services)
-		SCSCount := space.ServiceInstancesCount("p-spring-cloud-services")
-		SCDFCount := space.ServiceInstancesCount("p-dataflow-servers")
+		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
+		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
 		servicesCount -= (SCSCount + SCDFCount)
 	}
 	return servicesCount
@@ -184,8 +184,12 @@ func (space *Space) ServicesCount() int {
 	return servicesCount
 }
 
-// ServiceInstancesCount -
-func (space *Space) ServiceInstancesCount(serviceType string) int {
+// ServicesCountByServiceLabel returns the number of service instances
+// within a space which match the provided service label.
+//
+// Keep in mind, when we say "service label", we aren't talking about
+// metadata labels; this is the label property of the "service" object
+func (space *Space) ServicesCountByServiceLabel(serviceType string) int {
 	boundedServiceInstancesCount := 0
 	for _, service := range space.Services {
 		if strings.Contains(service.Label, serviceType) {
@@ -198,8 +202,8 @@ func (space *Space) ServiceInstancesCount(serviceType string) int {
 // Stats -
 func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 	for _, space := range spaces {
-		SCSCount := space.ServiceInstancesCount("p-spring-cloud-services")
-		SCDFCount := space.ServiceInstancesCount("p-dataflow-servers")
+		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
+		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
 		lApps := len(space.Apps)
 		rApps := space.RunningAppsCount()
 		sApps := lApps - rApps

--- a/models/models.go
+++ b/models/models.go
@@ -145,7 +145,16 @@ func (space *Space) ConsumedMemory() int {
 	return consumed
 }
 
-// RunningAppsCount -
+// RunningAppsCount returns the count of unique canonical app
+// guids with at least 1 running app instance
+//
+// for example, if you have the following result from `cf apps`:
+//
+// hammerdb-test                   stopped           0/1
+// nodejs-web                      started           2/2
+// push-test-webhook-switchboard   started           2/2
+//
+// then you'd have "2 running apps"
 func (space *Space) RunningAppsCount() int {
 	runningAppsCount := 0
 	for _, app := range space.Apps {
@@ -156,7 +165,16 @@ func (space *Space) RunningAppsCount() int {
 	return runningAppsCount
 }
 
-// InstancesCount -
+// InstancesCount returns the count of declared canonical app instances
+// regardless of start/stop state
+//
+// for example, if you have the following result from `cf apps`:
+//
+// hammerdb-test                   stopped           0/1
+// nodejs-web                      started           2/2
+// push-test-webhook-switchboard   started           2/2
+//
+// then you'd have "5 app instances"
 func (space *Space) InstancesCount() int {
 	instancesCount := 0
 	for _, app := range space.Apps {
@@ -165,7 +183,16 @@ func (space *Space) InstancesCount() int {
 	return instancesCount
 }
 
-// RunningInstancesCount -
+// RunningInstancesCount returns the count of declared canonical app instances
+// which are actively running
+//
+// for example, if you have the following result from `cf apps`:
+//
+// hammerdb-test                   stopped           0/1
+// nodejs-web                      started           2/2
+// push-test-webhook-switchboard   started           2/2
+//
+// then you'd have "4 running app instances"
 func (space *Space) RunningInstancesCount() int {
 	runningInstancesCount := 0
 	for _, app := range space.Apps {

--- a/models/models.go
+++ b/models/models.go
@@ -146,13 +146,14 @@ func (org *Org) ServicesCount() int {
 	return servicesCount
 }
 
-// ConsumedMemory -
+// ConsumedMemory returns the amount of memory consumed by all
+// running canonical application instances within a space
 func (space *Space) ConsumedMemory() int {
-	consumed := 0
+	consumedMemory := 0
 	for _, app := range space.Apps {
-		consumed += int(app.Actual * app.RAM)
+		consumedMemory += int(app.Actual * app.RAM)
 	}
-	return consumed
+	return consumedMemory
 }
 
 // RunningAppsCount returns the count of unique canonical app

--- a/models/models.go
+++ b/models/models.go
@@ -276,6 +276,7 @@ func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
 	count += space.ServicesCountByServiceLabel("p-dataflow-servers")
 
 	count += space.ServicesCountByServiceLabel("p-mysql")
+	count += space.ServicesCountByServiceLabel("p.mysql")
 	count += space.ServicesCountByServiceLabel("pivotal-mysql")
 
 	count += space.ServicesCountByServiceLabel("p-redis")

--- a/models/models.go
+++ b/models/models.go
@@ -115,7 +115,16 @@ func (org *Org) RunningInstancesCount() int {
 	return instancesCount
 }
 
-// AppsCount -
+// AppsCount returns the count of unique canonical app guids
+// regardless of start/stop state across all spaces within the org
+//
+// for example, within a space, if you have the following result from `cf apps`:
+//
+// hammerdb-test                   stopped           0/1
+// nodejs-web                      started           2/2
+// push-test-webhook-switchboard   started           2/2
+//
+// then you'd have "3 unique apps"
 func (org *Org) AppsCount() int {
 	appsCount := 0
 	for _, space := range org.Spaces {

--- a/models/models.go
+++ b/models/models.go
@@ -82,14 +82,12 @@ type Report struct {
 	Orgs Orgs
 }
 
-// InstancesCount -
-func (org *Org) InstancesCount() int {
+// AppInstancesCount returns the count of declared canonical app instances
+// regardless of start/stop state across all spaces within the org
+func (org *Org) AppInstancesCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
 		instancesCount += space.AppInstancesCount()
-		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
-		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
-		instancesCount += SCSCount + (SCDFCount * 3)
 	}
 	return instancesCount
 }
@@ -284,7 +282,7 @@ func (orgs Orgs) Stats(c chan OrgStats) {
 		lApps := org.AppsCount()
 		rApps := org.RunningAppsCount()
 		sApps := lApps - rApps
-		lAIs := org.InstancesCount()
+		lAIs := org.AppInstancesCount()
 		rAIs := org.RunningAppInstancesCount()
 		sAIs := lAIs - rAIs
 		c <- OrgStats{

--- a/models/models.go
+++ b/models/models.go
@@ -46,8 +46,14 @@ type SpaceStats struct {
 	DeployedAppInstancesCount  int
 	RunningAppInstancesCount   int
 	StoppedAppInstancesCount   int
-	ServicesCount              int
+	ServicesCount              int // TODO misnomer
 	ConsumedMemory             int
+
+	// (I know right? It's an intense name)
+	// Services matching "services suite for pivotal platform",
+	// e.g. Pivotal's mysql, redis, rmq offerings
+	// see: https://network.pivotal.io/products/pcf-services
+	ServicesSuiteForPivotalPlatformCount int
 
 	// includes anything which Pivotal deems "billable" as an AI, even if CF
 	// considers it a service; e.g., SCS instances (config server, service registry, etc.)

--- a/models/models.go
+++ b/models/models.go
@@ -174,7 +174,11 @@ func (space *Space) RunningInstancesCount() int {
 	return runningInstancesCount
 }
 
-// ServicesCount -
+// ServicesCount returns total count of registered services in the space
+// Keep in mind, if a single service ends up creating more service instances
+// (or application instances) in a different space (e.g., Spring Cloud Data Flow, etc.)
+// that's a different count. This is only for services registered within a given space,
+// which means they'd show up in a `cf services` call
 func (space *Space) ServicesCount() int {
 	servicesCount := len(space.Services)
 	return servicesCount

--- a/models/models.go
+++ b/models/models.go
@@ -248,6 +248,21 @@ func (space *Space) ServicesCount() int {
 	return count
 }
 
+// ServicesCountByServiceLabel returns the number of service instances
+// within a space which contain the provided service label.
+//
+// Keep in mind, when we say "service label", we aren't talking about
+// metadata labels; this is the label property of the "service" object
+func (space *Space) ServicesCountByServiceLabel(serviceType string) int {
+	count := 0
+	for _, service := range space.Services {
+		if strings.Contains(service.Label, serviceType) {
+			count++
+		}
+	}
+	return count
+}
+
 // ServicesSuiteForPivotalPlatformCount returns the number of service instances
 // part of the "services suite for pivotal platform", e.g. Pivotal's MySQL/Redis/RMQ
 //
@@ -269,21 +284,6 @@ func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
 	count += space.ServicesCountByServiceLabel("p-rabbitmq")
 	count += space.ServicesCountByServiceLabel("p.rabbitmq")
 
-	return count
-}
-
-// ServicesCountByServiceLabel returns the number of service instances
-// within a space which contain the provided service label.
-//
-// Keep in mind, when we say "service label", we aren't talking about
-// metadata labels; this is the label property of the "service" object
-func (space *Space) ServicesCountByServiceLabel(serviceType string) int {
-	count := 0
-	for _, service := range space.Services {
-		if strings.Contains(service.Label, serviceType) {
-			count++
-		}
-	}
 	return count
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -125,6 +125,8 @@ func (org *Org) RunningInstancesCount() int {
 // push-test-webhook-switchboard   started           2/2
 //
 // then you'd have "3 unique apps"
+//
+// TODO is this valuable? is this something that should be part of a Space type too?
 func (org *Org) AppsCount() int {
 	appsCount := 0
 	for _, space := range org.Spaces {

--- a/models/models.go
+++ b/models/models.go
@@ -94,7 +94,8 @@ func (org *Org) InstancesCount() int {
 	return instancesCount
 }
 
-// RunningAppsCount -
+// RunningAppsCount returns the count of unique canonical app
+// guids with at least 1 running app instance across all spaces within the org
 func (org *Org) RunningAppsCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
@@ -103,14 +104,12 @@ func (org *Org) RunningAppsCount() int {
 	return instancesCount
 }
 
-// RunningInstancesCount -
-func (org *Org) RunningInstancesCount() int {
+// RunningAppInstancesCount returns the count of declared canonical app instances
+// which are actively running across all spaces within the org
+func (org *Org) RunningAppInstancesCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
 		instancesCount += space.RunningAppInstancesCount()
-		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
-		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
-		instancesCount += SCSCount + (SCDFCount * 3)
 	}
 	return instancesCount
 }
@@ -286,7 +285,7 @@ func (orgs Orgs) Stats(c chan OrgStats) {
 		rApps := org.RunningAppsCount()
 		sApps := lApps - rApps
 		lAIs := org.InstancesCount()
-		rAIs := org.RunningInstancesCount()
+		rAIs := org.RunningAppInstancesCount()
 		sAIs := lAIs - rAIs
 		c <- OrgStats{
 			Name:                      org.Name,

--- a/models/models.go
+++ b/models/models.go
@@ -85,31 +85,31 @@ type Report struct {
 // AppInstancesCount returns the count of declared canonical app instances
 // regardless of start/stop state across all spaces within the org
 func (org *Org) AppInstancesCount() int {
-	instancesCount := 0
+	count := 0
 	for _, space := range org.Spaces {
-		instancesCount += space.AppInstancesCount()
+		count += space.AppInstancesCount()
 	}
-	return instancesCount
+	return count
 }
 
 // RunningAppsCount returns the count of unique canonical app
 // guids with at least 1 running app instance across all spaces within the org
 func (org *Org) RunningAppsCount() int {
-	instancesCount := 0
+	count := 0
 	for _, space := range org.Spaces {
-		instancesCount += space.RunningAppsCount()
+		count += space.RunningAppsCount()
 	}
-	return instancesCount
+	return count
 }
 
 // RunningAppInstancesCount returns the count of declared canonical app instances
 // which are actively running across all spaces within the org
 func (org *Org) RunningAppInstancesCount() int {
-	instancesCount := 0
+	count := 0
 	for _, space := range org.Spaces {
-		instancesCount += space.RunningAppInstancesCount()
+		count += space.RunningAppInstancesCount()
 	}
-	return instancesCount
+	return count
 }
 
 // AppsCount returns the count of unique canonical app guids
@@ -125,11 +125,11 @@ func (org *Org) RunningAppInstancesCount() int {
 //
 // TODO is this valuable? is this something that should be part of a Space type too?
 func (org *Org) AppsCount() int {
-	appsCount := 0
+	count := 0
 	for _, space := range org.Spaces {
-		appsCount += len(space.Apps)
+		count += len(space.Apps)
 	}
-	return appsCount
+	return count
 }
 
 // ServicesCount returns total count of registered services in all spaces of the org
@@ -139,21 +139,21 @@ func (org *Org) AppsCount() int {
 // those aren't considered in this result. This only counts services registered which
 // show up in `cf services`
 func (org *Org) ServicesCount() int {
-	servicesCount := 0
+	count := 0
 	for _, space := range org.Spaces {
-		servicesCount += len(space.Services)
+		count += len(space.Services)
 	}
-	return servicesCount
+	return count
 }
 
 // ConsumedMemory returns the amount of memory consumed by all
 // running canonical application instances within a space
 func (space *Space) ConsumedMemory() int {
-	consumedMemory := 0
+	count := 0
 	for _, app := range space.Apps {
-		consumedMemory += int(app.Actual * app.RAM)
+		count += int(app.Actual * app.RAM)
 	}
-	return consumedMemory
+	return count
 }
 
 // RunningAppsCount returns the count of unique canonical app
@@ -167,13 +167,13 @@ func (space *Space) ConsumedMemory() int {
 //
 // then you'd have "2 running apps"
 func (space *Space) RunningAppsCount() int {
-	runningAppsCount := 0
+	count := 0
 	for _, app := range space.Apps {
 		if app.Actual > 0 {
-			runningAppsCount++
+			count++
 		}
 	}
-	return runningAppsCount
+	return count
 }
 
 // AppInstancesCount returns the count of declared canonical app instances
@@ -187,11 +187,11 @@ func (space *Space) RunningAppsCount() int {
 //
 // then you'd have "5 app instances"
 func (space *Space) AppInstancesCount() int {
-	appInstancesCount := 0
+	count := 0
 	for _, app := range space.Apps {
-		appInstancesCount += int(app.Desire)
+		count += int(app.Desire)
 	}
-	return appInstancesCount
+	return count
 }
 
 // RunningAppInstancesCount returns the count of declared canonical app instances
@@ -205,11 +205,11 @@ func (space *Space) AppInstancesCount() int {
 //
 // then you'd have "4 running app instances"
 func (space *Space) RunningAppInstancesCount() int {
-	runningAppInstancesCount := 0
+	count := 0
 	for _, app := range space.Apps {
-		runningAppInstancesCount += int(app.Actual)
+		count += int(app.Actual)
 	}
-	return runningAppInstancesCount
+	return count
 }
 
 // ServicesCount returns total count of registered services in the space
@@ -219,8 +219,8 @@ func (space *Space) RunningAppInstancesCount() int {
 // those aren't considered in this result. This only counts services registered which
 // show up in `cf services`
 func (space *Space) ServicesCount() int {
-	servicesCount := len(space.Services)
-	return servicesCount
+	count := len(space.Services)
+	return count
 }
 
 // ServicesCountByServiceLabel returns the number of service instances
@@ -229,13 +229,13 @@ func (space *Space) ServicesCount() int {
 // Keep in mind, when we say "service label", we aren't talking about
 // metadata labels; this is the label property of the "service" object
 func (space *Space) ServicesCountByServiceLabel(serviceType string) int {
-	matchingServices := 0
+	count := 0
 	for _, service := range space.Services {
 		if strings.Contains(service.Label, serviceType) {
-			matchingServices++
+			count++
 		}
 	}
-	return matchingServices
+	return count
 }
 
 // Stats -

--- a/models/models.go
+++ b/models/models.go
@@ -130,8 +130,6 @@ func (org *Org) RunningAppInstancesCount() int {
 // push-test-webhook-switchboard   started           2/2
 //
 // then you'd have "3 unique apps"
-//
-// TODO is this valuable? is this something that should be part of a Space type too?
 func (org *Org) AppsCount() int {
 	count := 0
 	for _, space := range org.Spaces {
@@ -220,6 +218,21 @@ func (space *Space) RunningAppInstancesCount() int {
 	return count
 }
 
+// AppsCount returns the count of unique canonical app guids
+// regardless of start/stop state
+//
+// for example, if you have the following result from `cf apps`:
+//
+// hammerdb-test                   stopped           0/1
+// nodejs-web                      started           2/2
+// push-test-webhook-switchboard   started           2/2
+//
+// then you'd have "3 unique apps"
+func (space *Space) AppsCount() int {
+	count := len(space.Apps)
+	return count
+}
+
 // ServicesCount returns total count of registered services in the space
 //
 // Keep in mind, if a single service ends up creating more service instances
@@ -251,7 +264,7 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 	for _, space := range spaces {
 		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
 		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
-		lApps := len(space.Apps)
+		lApps := space.AppsCount()
 		rApps := space.RunningAppsCount()
 		sApps := lApps - rApps
 		// "canonical" appInstances are what we can use for setting a quota

--- a/models/models.go
+++ b/models/models.go
@@ -48,6 +48,10 @@ type SpaceStats struct {
 	StoppedAppInstancesCount   int
 	ServicesCount              int
 	ConsumedMemory             int
+
+	// includes anything which Pivotal deems "billable" as an AI, even if CF
+	// considers it a service; e.g., SCS instances (config server, service registry, etc.)
+	BillableAppInstancesCount int
 }
 
 // OrgStats -
@@ -63,6 +67,10 @@ type OrgStats struct {
 	RunningAppInstancesCount  int
 	StoppedAppInstancesCount  int
 	ServicesCount             int
+
+	// includes anything which Pivotal deems "billable" as an AI, even if CF
+	// considers it a service; e.g., SCS instances (config server, service registry, etc.)
+	BillableAppInstancesCount int
 }
 
 // Orgs -

--- a/models/models.go
+++ b/models/models.go
@@ -190,13 +190,13 @@ func (space *Space) ServicesCount() int {
 // Keep in mind, when we say "service label", we aren't talking about
 // metadata labels; this is the label property of the "service" object
 func (space *Space) ServicesCountByServiceLabel(serviceType string) int {
-	boundedServiceInstancesCount := 0
+	matchingServices := 0
 	for _, service := range space.Services {
 		if strings.Contains(service.Label, serviceType) {
-			boundedServiceInstancesCount++
+			matchingServices++
 		}
 	}
-	return boundedServiceInstancesCount
+	return matchingServices
 }
 
 // Stats -

--- a/models/models.go
+++ b/models/models.go
@@ -162,6 +162,21 @@ func (space *Space) ConsumedMemory() int {
 	return count
 }
 
+// AppsCount returns the count of unique canonical app guids
+// regardless of start/stop state
+//
+// for example, if you have the following result from `cf apps`:
+//
+// hammerdb-test                   stopped           0/1
+// nodejs-web                      started           2/2
+// push-test-webhook-switchboard   started           2/2
+//
+// then you'd have "3 unique apps"
+func (space *Space) AppsCount() int {
+	count := len(space.Apps)
+	return count
+}
+
 // RunningAppsCount returns the count of unique canonical app
 // guids with at least 1 running app instance
 //
@@ -215,21 +230,6 @@ func (space *Space) RunningAppInstancesCount() int {
 	for _, app := range space.Apps {
 		count += int(app.Actual)
 	}
-	return count
-}
-
-// AppsCount returns the count of unique canonical app guids
-// regardless of start/stop state
-//
-// for example, if you have the following result from `cf apps`:
-//
-// hammerdb-test                   stopped           0/1
-// nodejs-web                      started           2/2
-// push-test-webhook-switchboard   started           2/2
-//
-// then you'd have "3 unique apps"
-func (space *Space) AppsCount() int {
-	count := len(space.Apps)
 	return count
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -49,11 +49,7 @@ type SpaceStats struct {
 	ServicesCount              int // TODO misnomer
 	ConsumedMemory             int
 
-	// (I know right? It's an intense name)
-	// Services matching "services suite for pivotal platform",
-	// e.g. Pivotal's mysql, redis, rmq offerings
-	// see: https://network.pivotal.io/products/pcf-services
-	ServicesSuiteForPivotalPlatformCount int
+	ServicesSuiteForPivotalPlatformCount int // TODO
 
 	// includes anything which Pivotal deems "billable" as an AI, even if CF
 	// considers it a service; e.g., SCS instances (config server, service registry, etc.)
@@ -73,6 +69,8 @@ type OrgStats struct {
 	RunningAppInstancesCount  int
 	StoppedAppInstancesCount  int
 	ServicesCount             int
+
+	ServicesSuiteForPivotalPlatformCount int // TODO
 
 	// includes anything which Pivotal deems "billable" as an AI, even if CF
 	// considers it a service; e.g., SCS instances (config server, service registry, etc.)
@@ -250,8 +248,32 @@ func (space *Space) ServicesCount() int {
 	return count
 }
 
+// ServicesSuiteForPivotalPlatformCount returns the number of service instances
+// part of the "services suite for pivotal platform", e.g. Pivotal's MySQL/Redis/RMQ
+//
+// see: https://network.pivotal.io/products/pcf-services
+// (I know right? It's an intense function name)
+//
+// TODO come back and figure out labeling more appropriately
+func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
+	count := 0
+
+	count += space.ServicesCountByServiceLabel("p-dataflow-servers")
+
+	count += space.ServicesCountByServiceLabel("p-mysql")
+	count += space.ServicesCountByServiceLabel("pivotal-mysql")
+
+	count += space.ServicesCountByServiceLabel("p-redis")
+	count += space.ServicesCountByServiceLabel("p.redis")
+
+	count += space.ServicesCountByServiceLabel("p-rabbitmq")
+	count += space.ServicesCountByServiceLabel("p.rabbitmq")
+
+	return count
+}
+
 // ServicesCountByServiceLabel returns the number of service instances
-// within a space which match the provided service label.
+// within a space which contain the provided service label.
 //
 // Keep in mind, when we say "service label", we aren't talking about
 // metadata labels; this is the label property of the "service" object

--- a/models/models.go
+++ b/models/models.go
@@ -107,7 +107,7 @@ func (org *Org) RunningAppsCount() int {
 func (org *Org) RunningInstancesCount() int {
 	instancesCount := 0
 	for _, space := range org.Spaces {
-		instancesCount += space.RunningInstancesCount()
+		instancesCount += space.RunningAppInstancesCount()
 		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
 		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
 		instancesCount += SCSCount + (SCDFCount * 3)
@@ -183,7 +183,7 @@ func (space *Space) InstancesCount() int {
 	return instancesCount
 }
 
-// RunningInstancesCount returns the count of declared canonical app instances
+// RunningAppInstancesCount returns the count of declared canonical app instances
 // which are actively running
 //
 // for example, if you have the following result from `cf apps`:
@@ -193,12 +193,12 @@ func (space *Space) InstancesCount() int {
 // push-test-webhook-switchboard   started           2/2
 //
 // then you'd have "4 running app instances"
-func (space *Space) RunningInstancesCount() int {
-	runningInstancesCount := 0
+func (space *Space) RunningAppInstancesCount() int {
+	runningAppInstancesCount := 0
 	for _, app := range space.Apps {
-		runningInstancesCount += int(app.Actual)
+		runningAppInstancesCount += int(app.Actual)
 	}
-	return runningInstancesCount
+	return runningAppInstancesCount
 }
 
 // ServicesCount returns total count of registered services in the space
@@ -240,7 +240,7 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		// with the existing logic before getting a chance to rework this
 		lAIs := space.InstancesCount()
 		lAIs += (SCSCount + (SCDFCount * 3))
-		rAIs := space.RunningInstancesCount()
+		rAIs := space.RunningAppInstancesCount()
 		rAIs += (SCSCount + (SCDFCount * 3))
 		sAIs := lAIs - rAIs
 		siCount := space.ServicesCount()

--- a/models/models.go
+++ b/models/models.go
@@ -124,14 +124,16 @@ func (org *Org) AppsCount() int {
 	return appsCount
 }
 
-// ServicesCount -
+// ServicesCount returns total count of registered services in all spaces of the org
+//
+// Keep in mind, if a single service ends up creating more service instances
+// (or application instances) in a different space (e.g., Spring Cloud Data Flow, etc.)
+// those aren't considered in this result. This only counts services registered which
+// show up in `cf services`
 func (org *Org) ServicesCount() int {
 	servicesCount := 0
 	for _, space := range org.Spaces {
 		servicesCount += len(space.Services)
-		SCSCount := space.ServicesCountByServiceLabel("p-spring-cloud-services")
-		SCDFCount := space.ServicesCountByServiceLabel("p-dataflow-servers")
-		servicesCount -= (SCSCount + SCDFCount)
 	}
 	return servicesCount
 }
@@ -202,10 +204,11 @@ func (space *Space) RunningAppInstancesCount() int {
 }
 
 // ServicesCount returns total count of registered services in the space
+//
 // Keep in mind, if a single service ends up creating more service instances
 // (or application instances) in a different space (e.g., Spring Cloud Data Flow, etc.)
-// that's a different count. This is only for services registered within a given space,
-// which means they'd show up in a `cf services` call
+// those aren't considered in this result. This only counts services registered which
+// show up in `cf services`
 func (space *Space) ServicesCount() int {
 	servicesCount := len(space.Services)
 	return servicesCount

--- a/models/models.go
+++ b/models/models.go
@@ -297,6 +297,8 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		stoppedUniqueApps := totalUniqueApps - runningUniqueApps
 		// "canonical" appInstances are what we can use for setting a quota
 		canonicalAppInstances := space.AppInstancesCount()
+		// What _used_ to be reported as just "services"
+		servicesSuiteForPivotalPlatformCount := space.ServicesSuiteForPivotalPlatformCount()
 		// "lAIs" in this context is really "billableAIs", but I don't want to mess
 		// with the existing logic before getting a chance to rework this
 		lAIs := space.AppInstancesCount()
@@ -311,16 +313,17 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 			siCount = 0
 		}
 		c <- SpaceStats{
-			Name:                       space.Name,
-			DeployedAppsCount:          totalUniqueApps,
-			RunningAppsCount:           runningUniqueApps,
-			StoppedAppsCount:           stoppedUniqueApps,
-			CanonicalAppInstancesCount: canonicalAppInstances,
-			DeployedAppInstancesCount:  lAIs,
-			RunningAppInstancesCount:   rAIs,
-			StoppedAppInstancesCount:   sAIs,
-			ServicesCount:              siCount,
-			ConsumedMemory:             rAIConsumedMemory,
+			Name:                                 space.Name,
+			DeployedAppsCount:                    totalUniqueApps,
+			RunningAppsCount:                     runningUniqueApps,
+			StoppedAppsCount:                     stoppedUniqueApps,
+			CanonicalAppInstancesCount:           canonicalAppInstances,
+			DeployedAppInstancesCount:            lAIs,
+			RunningAppInstancesCount:             rAIs,
+			StoppedAppInstancesCount:             sAIs,
+			ServicesCount:                        siCount,
+			ConsumedMemory:                       rAIConsumedMemory,
+			ServicesSuiteForPivotalPlatformCount: servicesSuiteForPivotalPlatformCount,
 		}
 	}
 	close(c)
@@ -394,7 +397,7 @@ func (report *Report) String() string {
 
 			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
 
-			response.WriteString(fmt.Sprintf(spaceServiceSuiteMsg, spaceState.ServicesCount))
+			response.WriteString(fmt.Sprintf(spaceServiceSuiteMsg, spaceState.ServicesSuiteForPivotalPlatformCount))
 
 		}
 		totalApps += orgStats.DeployedAppsCount


### PR DESCRIPTION
see: https://github.com/aegershman/cf-trueup-plugin/issues/21

Avoid premature filtering of space summary

Rename ServiceInstances function to ServicesCountByServiceLabel to describe it as a function which gets a count by label

Include examples in models function methods

Move service filtering logic to a different location besides the apihelper method

rename InstancesCount to be more specific about APP instances being used

rename InstancesCount to be specific about AppInstances being used

---

before modifying stats:

```txt
Org gershman is consuming 24 MB of 25600 MB.
        Space dev is consuming 24 MB memory (0%) of org quota.
                2 canonical app instances
                2 billable app instances: 2 running, 0 stopped
                1 unique app_guids: 1 running 0 stopped
                5 service instances of type Service Suite (mysql, redis, rmq)
[WARNING: THIS REPORT SUMMARY IS MISLEADING AND INCORRECT. IT WILL BE FIXED SOON.] You have deployed 1 apps across 1 org(s), with a total of 2 app instances configured. You are currently running 1 apps with 2 app instances and using 5 service instances of type Service Suite.
```

after modifying space stats to report pivotal services properly

```txt
Org gershman is consuming 24 MB of 25600 MB.
        Space dev is consuming 24 MB memory (0%) of org quota.
                2 canonical app instances
                2 billable app instances: 2 running, 0 stopped
                1 unique app_guids: 1 running 0 stopped
                0 service instances of type Service Suite (mysql, redis, rmq)
[WARNING: THIS REPORT SUMMARY IS MISLEADING AND INCORRECT. IT WILL BE FIXED SOON.] You have deployed 1 apps across 1 org(s), with a total of 2 app instances configured. You are currently running 1 apps with 2 app instances and using 5 service instances of type Service Suite.
```