### PR TITLE
Cleanup internal API to modularize how stats are calculated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 trueupreport.go.bak
 .DS_Store
 dist
+hack

--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Name: "cf-trueup-plugin",
 		Version: plugin.VersionType{
 			Major: 2,
-			Minor: 6,
-			Build: 2,
+			Minor: 7,
+			Build: 0,
 		},
 		Commands: []plugin.Command{
 			{

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 2,
 			Minor: 6,
-			Build: 1,
+			Build: 2,
 		},
 		Commands: []plugin.Command{
 			{

--- a/models/models.go
+++ b/models/models.go
@@ -38,16 +38,15 @@ type Service struct {
 // of Spaces; we can use it as a way to decorate
 // a Space with extra info like billableAIs, etc.
 type SpaceStats struct {
-	Name                       string
-	AppsCount                  int
-	RunningAppsCount           int
-	StoppedAppsCount           int
-	CanonicalAppInstancesCount int
-	AppInstancesCount          int
-	RunningAppInstancesCount   int
-	StoppedAppInstancesCount   int
-	ServicesCount              int // TODO misnomer
-	ConsumedMemory             int
+	Name                     string
+	AppsCount                int
+	RunningAppsCount         int
+	StoppedAppsCount         int
+	AppInstancesCount        int
+	RunningAppInstancesCount int
+	StoppedAppInstancesCount int
+	ServicesCount            int // TODO misnomer
+	ConsumedMemory           int
 
 	ServicesSuiteForPivotalPlatformCount int // TODO
 
@@ -319,9 +318,6 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		runningUniqueApps := space.RunningAppsCount()
 		stoppedUniqueApps := totalUniqueApps - runningUniqueApps
 
-		// "canonical" appInstances are what we can use for setting a quota
-		canonicalAppInstances := space.AppInstancesCount()
-
 		// What _used_ to be reported as just "services"
 		servicesSuiteForPivotalPlatformCount := space.ServicesSuiteForPivotalPlatformCount()
 
@@ -341,7 +337,6 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 			AppsCount:                            totalUniqueApps,
 			RunningAppsCount:                     runningUniqueApps,
 			StoppedAppsCount:                     stoppedUniqueApps,
-			CanonicalAppInstancesCount:           canonicalAppInstances,
 			AppInstancesCount:                    appInstancesCount,
 			RunningAppInstancesCount:             runningAppInstancesCount,
 			StoppedAppInstancesCount:             stoppedAppInstancesCount,
@@ -415,7 +410,7 @@ func (report *Report) String() string {
 				response.WriteString(fmt.Sprintf(spaceOverviewMsg, spaceState.Name, spaceState.ConsumedMemory, spaceMemoryConsumedPercentage))
 			}
 
-			response.WriteString(fmt.Sprintf(spaceCanonicalAppInstancesMsg, spaceState.CanonicalAppInstancesCount))
+			response.WriteString(fmt.Sprintf(spaceCanonicalAppInstancesMsg, spaceState.AppInstancesCount))
 
 			response.WriteString(
 				fmt.Sprintf(spaceBillableAppInstancesMsg, spaceState.AppInstancesCount, spaceState.RunningAppInstancesCount, spaceState.StoppedAppInstancesCount))

--- a/models/models.go
+++ b/models/models.go
@@ -358,9 +358,11 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 // Stats -
 func (orgs Orgs) Stats(c chan OrgStats) {
 	for _, org := range orgs {
-		lApps := org.AppsCount()
-		rApps := org.RunningAppsCount()
-		sApps := lApps - rApps
+
+		totalUniqueApps := org.AppsCount()
+		runningUniqueApps := org.RunningAppsCount()
+		stoppedUniqueApps := totalUniqueApps - runningUniqueApps
+
 		lAIs := org.AppInstancesCount()
 		rAIs := org.RunningAppInstancesCount()
 		sAIs := lAIs - rAIs
@@ -369,9 +371,9 @@ func (orgs Orgs) Stats(c chan OrgStats) {
 			MemoryQuota:              org.MemoryQuota,
 			MemoryUsage:              org.MemoryUsage,
 			Spaces:                   org.Spaces,
-			AppsCount:                lApps,
-			RunningAppsCount:         rApps,
-			StoppedAppsCount:         sApps,
+			AppsCount:                totalUniqueApps,
+			RunningAppsCount:         runningUniqueApps,
+			StoppedAppsCount:         stoppedUniqueApps,
 			AppInstancesCount:        lAIs,
 			RunningAppInstancesCount: rAIs,
 			StoppedAppInstancesCount: sAIs,

--- a/models/models.go
+++ b/models/models.go
@@ -3,7 +3,6 @@ package models
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -290,8 +289,6 @@ func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
 
 	count += space.ServicesCountByServiceLabel("p-rabbitmq")
 	count += space.ServicesCountByServiceLabel("p.rabbitmq")
-
-	log.Println(count)
 
 	return count
 }

--- a/models/models.go
+++ b/models/models.go
@@ -39,7 +39,7 @@ type Service struct {
 // a Space with extra info like billableAIs, etc.
 type SpaceStats struct {
 	Name                       string
-	DeployedAppsCount          int
+	AppsCount                  int
 	RunningAppsCount           int
 	StoppedAppsCount           int
 	CanonicalAppInstancesCount int
@@ -66,7 +66,7 @@ type OrgStats struct {
 	MemoryQuota               int
 	MemoryUsage               int
 	Spaces                    Spaces
-	DeployedAppsCount         int
+	AppsCount                 int
 	RunningAppsCount          int
 	StoppedAppsCount          int
 	DeployedAppInstancesCount int
@@ -314,27 +314,33 @@ func (space *Space) SpringCloudServicesCount() int {
 // Stats -
 func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 	for _, space := range spaces {
+
 		totalUniqueApps := space.AppsCount()
 		runningUniqueApps := space.RunningAppsCount()
 		stoppedUniqueApps := totalUniqueApps - runningUniqueApps
+
 		// "canonical" appInstances are what we can use for setting a quota
 		canonicalAppInstances := space.AppInstancesCount()
+
 		// What _used_ to be reported as just "services"
 		servicesSuiteForPivotalPlatformCount := space.ServicesSuiteForPivotalPlatformCount()
+
 		// "lAIs" in this context is really "billableAIs", but I don't want to mess
 		// with the existing logic before getting a chance to rework this
 		lAIs := space.AppInstancesCount()
 		rAIs := space.RunningAppInstancesCount()
 		sAIs := lAIs - rAIs
+
 		consumedMemory := space.ConsumedMemory()
 		servicesCount := space.ServicesCount()
 		billableServicesCount := servicesCount - space.SpringCloudServicesCount()
 		if skipSIcount {
 			servicesCount = 0
 		}
+
 		c <- SpaceStats{
 			Name:                                 space.Name,
-			DeployedAppsCount:                    totalUniqueApps,
+			AppsCount:                            totalUniqueApps,
 			RunningAppsCount:                     runningUniqueApps,
 			StoppedAppsCount:                     stoppedUniqueApps,
 			CanonicalAppInstancesCount:           canonicalAppInstances,
@@ -364,7 +370,7 @@ func (orgs Orgs) Stats(c chan OrgStats) {
 			MemoryQuota:               org.MemoryQuota,
 			MemoryUsage:               org.MemoryUsage,
 			Spaces:                    org.Spaces,
-			DeployedAppsCount:         lApps,
+			AppsCount:                 lApps,
 			RunningAppsCount:          rApps,
 			StoppedAppsCount:          sApps,
 			DeployedAppInstancesCount: lAIs,
@@ -416,12 +422,12 @@ func (report *Report) String() string {
 			response.WriteString(
 				fmt.Sprintf(spaceBillableAppInstancesMsg, spaceState.DeployedAppInstancesCount, spaceState.RunningAppInstancesCount, spaceState.StoppedAppInstancesCount))
 
-			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.DeployedAppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
+			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.AppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
 
 			response.WriteString(fmt.Sprintf(spaceServiceSuiteMsg, spaceState.ServicesSuiteForPivotalPlatformCount))
 
 		}
-		totalApps += orgStats.DeployedAppsCount
+		totalApps += orgStats.AppsCount
 		totalInstances += orgStats.DeployedAppInstancesCount
 		totalRunningApps += orgStats.RunningAppsCount
 		totalRunningInstances += orgStats.RunningAppInstancesCount

--- a/models/models.go
+++ b/models/models.go
@@ -3,6 +3,7 @@ package models
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -275,8 +276,6 @@ func (space *Space) ServicesCountByServiceLabel(serviceType string) int {
 //
 // see: https://network.pivotal.io/products/pcf-services
 // (I know right? It's an intense function name)
-//
-// TODO come back and figure out labeling more appropriately
 func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
 	count := 0
 
@@ -292,6 +291,8 @@ func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
 	count += space.ServicesCountByServiceLabel("p-rabbitmq")
 	count += space.ServicesCountByServiceLabel("p.rabbitmq")
 
+	log.Println(count)
+
 	return count
 }
 
@@ -299,13 +300,17 @@ func (space *Space) ServicesSuiteForPivotalPlatformCount() int {
 // from "spring cloud services" tile, e.g. config-server/service-registry/circuit-breaker/etc.
 //
 // see: https://network.pivotal.io/products/p-spring-cloud-services/
-//
-// TODO come back and figure out labeling more appropriately
 func (space *Space) SpringCloudServicesCount() int {
 	count := 0
 
-	count += space.ServicesCountByServiceLabel("p-spring-cloud-services")
-	count += space.ServicesCountByServiceLabel("scs-service-broker")
+	// scs 2.x
+	count += space.ServicesCountByServiceLabel("p-config-server")
+	count += space.ServicesCountByServiceLabel("p-service-registry")
+	count += space.ServicesCountByServiceLabel("p-circuit-breaker")
+
+	// scs 3.x
+	count += space.ServicesCountByServiceLabel("p.config-server")
+	count += space.ServicesCountByServiceLabel("p.service-registry")
 
 	return count
 }

--- a/models/models.go
+++ b/models/models.go
@@ -325,6 +325,9 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		runningAppInstancesCount := space.RunningAppInstancesCount()
 		stoppedAppInstancesCount := appInstancesCount - runningAppInstancesCount
 
+		billableAppInstancesCount := space.AppInstancesCount()
+		billableAppInstancesCount += space.SpringCloudServicesCount()
+
 		consumedMemory := space.ConsumedMemory()
 		servicesCount := space.ServicesCount()
 		billableServicesCount := servicesCount - space.SpringCloudServicesCount()
@@ -343,6 +346,7 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 			ServicesCount:                        servicesCount,
 			ConsumedMemory:                       consumedMemory,
 			ServicesSuiteForPivotalPlatformCount: servicesSuiteForPivotalPlatformCount,
+			BillableAppInstancesCount:            billableAppInstancesCount,
 			BillableServicesCount:                billableServicesCount,
 		}
 	}
@@ -388,7 +392,7 @@ func (report *Report) String() string {
 		orgOverviewMsg                = "Org %s is consuming %d MB of %d MB.\n"
 		spaceOverviewMsg              = "\tSpace %s is consuming %d MB memory (%d%%) of org quota.\n"
 		spaceCanonicalAppInstancesMsg = "\t\t%d canonical app instances\n"
-		spaceBillableAppInstancesMsg  = "\t\t%d billable app instances: %d running, %d stopped\n"
+		spaceBillableAppInstancesMsg  = "\t\t%d billable app instances (includes AIs and billable SIs, like SCS)\n"
 		spaceUniqueAppGuidsMsg        = "\t\t%d unique app_guids: %d running %d stopped\n"
 		spaceServiceSuiteMsg          = "\t\t%d service instances of type Service Suite (mysql, redis, rmq)\n"
 		reportSummaryMsg              = "[WARNING: THIS REPORT SUMMARY IS MISLEADING AND INCORRECT. IT WILL BE FIXED SOON.] You have deployed %d apps across %d org(s), with a total of %d app instances configured. You are currently running %d apps with %d app instances and using %d service instances of type Service Suite.\n"
@@ -412,8 +416,7 @@ func (report *Report) String() string {
 
 			response.WriteString(fmt.Sprintf(spaceCanonicalAppInstancesMsg, spaceState.AppInstancesCount))
 
-			response.WriteString(
-				fmt.Sprintf(spaceBillableAppInstancesMsg, spaceState.AppInstancesCount, spaceState.RunningAppInstancesCount, spaceState.StoppedAppInstancesCount))
+			response.WriteString(fmt.Sprintf(spaceBillableAppInstancesMsg, spaceState.BillableAppInstancesCount))
 
 			response.WriteString(fmt.Sprintf(spaceUniqueAppGuidsMsg, spaceState.AppsCount, spaceState.RunningAppsCount, spaceState.StoppedAppsCount))
 

--- a/models/models.go
+++ b/models/models.go
@@ -54,6 +54,10 @@ type SpaceStats struct {
 	// includes anything which Pivotal deems "billable" as an AI, even if CF
 	// considers it a service; e.g., SCS instances (config server, service registry, etc.)
 	BillableAppInstancesCount int
+
+	// count of anything which Pivotal deems "billable" as an SI; this might mean
+	// subtracting certain services (like SCS) from the count of `cf services`
+	BillableServicesCount int
 }
 
 // OrgStats -
@@ -75,6 +79,10 @@ type OrgStats struct {
 	// includes anything which Pivotal deems "billable" as an AI, even if CF
 	// considers it a service; e.g., SCS instances (config server, service registry, etc.)
 	BillableAppInstancesCount int
+
+	// count of anything which Pivotal deems "billable" as an SI; this might mean
+	// subtracting certain services (like SCS) from the count of `cf services`
+	BillableServicesCount int
 }
 
 // Orgs -

--- a/models/models.go
+++ b/models/models.go
@@ -307,9 +307,9 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 		rAIs := space.RunningAppInstancesCount()
 		rAIs += (SCSCount + (SCDFCount * 3))
 		sAIs := lAIs - rAIs
+		consumedMemory := space.ConsumedMemory()
 		siCount := space.ServicesCount()
 		siCount -= (SCSCount + SCDFCount)
-		rAIConsumedMemory := (space.ConsumedMemory() + (SCSCount * 1024) + (SCDFCount * 3 * 1024))
 		if skipSIcount {
 			siCount = 0
 		}
@@ -323,7 +323,7 @@ func (spaces Spaces) Stats(c chan SpaceStats, skipSIcount bool) {
 			RunningAppInstancesCount:             rAIs,
 			StoppedAppInstancesCount:             sAIs,
 			ServicesCount:                        siCount,
-			ConsumedMemory:                       rAIConsumedMemory,
+			ConsumedMemory:                       consumedMemory,
 			ServicesSuiteForPivotalPlatformCount: servicesSuiteForPivotalPlatformCount,
 		}
 	}


### PR DESCRIPTION
see: https://github.com/aegershman/cf-trueup-plugin/issues/21

Don't assume that SCDF and SCS memory consumption should be included in the "memory consumed" report.

Break out SCS method for spaces

Break out billableServiceInstances from just "service instances"