### PR TITLE
tablewriter / alt. reporting techniques

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	code.cloudfoundry.org/cli v6.47.2+incompatible // indirect
 	github.com/cloudfoundry/cli v6.47.2+incompatible
+	github.com/olekukonko/tablewriter v0.0.3
 	github.com/onsi/ginkgo v1.10.3 // indirect
 	github.com/onsi/gomega v1.7.1 // indirect
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/mattn/go-runewidth v0.0.6 h1:V2iyH+aX9C5fsYCpK60U8BYIvmhqxuOL3JZcqc1NB7k=
+github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.3 h1:i0LBnzgiChAWHJYTQAZJDOgf8MNxAVYZJ2m63SIDimI=
+github.com/olekukonko/tablewriter v0.0.3/go.mod h1:YZeBtGzYYEsCHp2LST/u/0NDwGkRoBtmn1cIWCJiS6M=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/main.go
+++ b/main.go
@@ -85,7 +85,8 @@ func (cmd *UsageReportCmd) UsageReportCommand(args []string) {
 
 	report.Orgs = orgs
 
-	fmt.Println(report.String())
+	// fmt.Println(report.String())
+	report.Stringg() // TODO, of course
 }
 
 func (cmd *UsageReportCmd) getOrgs() ([]models.Org, error) {

--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Name: "cf-trueup-plugin",
 		Version: plugin.VersionType{
 			Major: 2,
-			Minor: 7,
-			Build: 1,
+			Minor: 8,
+			Build: 0,
 		},
 		Commands: []plugin.Command{
 			{

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aegershman/cf-trueup-plugin/apihelper"
 	"github.com/aegershman/cf-trueup-plugin/models"
+	p "github.com/aegershman/cf-trueup-plugin/presenters"
 	"github.com/cloudfoundry/cli/plugin"
 )
 
@@ -34,8 +35,8 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Name: "cf-trueup-plugin",
 		Version: plugin.VersionType{
 			Major: 2,
-			Minor: 8,
-			Build: 0,
+			Minor: 7,
+			Build: 2,
 		},
 		Commands: []plugin.Command{
 			{
@@ -85,8 +86,8 @@ func (cmd *UsageReportCmd) UsageReportCommand(args []string) {
 
 	report.Orgs = orgs
 
-	// fmt.Println(report.String())
-	report.Stringg() // TODO, of course
+	presenter := p.NewPresenter(report)
+	presenter.AsString()
 }
 
 func (cmd *UsageReportCmd) getOrgs() ([]models.Org, error) {

--- a/models/reportTableGoof.go
+++ b/models/reportTableGoof.go
@@ -20,20 +20,23 @@ func (report *Report) Stringg() {
 		// TODO dynamic filtering?
 		go orgStats.Spaces.Stats(chSpaceStats, orgStats.Name == "p-spring-cloud-services")
 
+		// TODO just testing, just goofing off, I know this is wrong, etc...
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
+		table.SetHeader([]string{"Space", "MB", "cAIs", "bAIs", "cSIs", "bSIs"})
+
 		for spaceState := range chSpaceStats {
-
-			// TODO just testing, just goofing off, I know this is wrong, etc...
-
-			table := tablewriter.NewWriter(os.Stdout)
-			table.SetAlignment(tablewriter.ALIGN_LEFT)
-
-			table.SetHeader([]string{"Name", "MB Consumed", "App Instances"})
-
-			table.Append([]string{spaceState.Name, strconv.Itoa(spaceState.ConsumedMemory), strconv.Itoa(spaceState.AppInstancesCount)})
-
-			table.Render()
-
+			table.Append([]string{
+				spaceState.Name,
+				strconv.Itoa(spaceState.ConsumedMemory),
+				strconv.Itoa(spaceState.AppInstancesCount),
+				strconv.Itoa(spaceState.BillableAppInstancesCount),
+				strconv.Itoa(spaceState.ServicesCount),
+				strconv.Itoa(spaceState.BillableServicesCount),
+			})
 		}
+
+		table.Render()
 
 	}
 

--- a/models/reportTableGoof.go
+++ b/models/reportTableGoof.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// Stringg -
+func (report *Report) Stringg() {
+
+	chOrgStats := make(chan OrgStats, len(report.Orgs))
+
+	go report.Orgs.Stats(chOrgStats)
+	for orgStats := range chOrgStats {
+
+		chSpaceStats := make(chan SpaceStats, len(orgStats.Spaces))
+
+		// TODO dynamic filtering?
+		go orgStats.Spaces.Stats(chSpaceStats, orgStats.Name == "p-spring-cloud-services")
+
+		for spaceState := range chSpaceStats {
+
+			// TODO just testing, just goofing off, I know this is wrong, etc...
+
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetAlignment(tablewriter.ALIGN_LEFT)
+
+			table.SetHeader([]string{"Name", "MB Consumed", "App Instances"})
+
+			table.Append([]string{spaceState.Name, strconv.Itoa(spaceState.ConsumedMemory), strconv.Itoa(spaceState.AppInstancesCount)})
+
+			table.Render()
+
+		}
+
+	}
+
+}

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -1,0 +1,17 @@
+package presenters
+
+import (
+	m "github.com/aegershman/cf-trueup-plugin/models"
+)
+
+// Presenter -
+type Presenter struct {
+	Report m.Report
+}
+
+// NewPresenter -
+func NewPresenter(r m.Report) Presenter {
+	return Presenter{
+		Report: r,
+	}
+}

--- a/presenters/tablePresenter.go
+++ b/presenters/tablePresenter.go
@@ -1,21 +1,22 @@
-package models
+package presenters
 
 import (
 	"os"
 	"strconv"
 
+	m "github.com/aegershman/cf-trueup-plugin/models"
 	"github.com/olekukonko/tablewriter"
 )
 
-// Stringg -
-func (report *Report) Stringg() {
+// AsTable -
+func (p *Presenter) AsTable() {
 
-	chOrgStats := make(chan OrgStats, len(report.Orgs))
+	chOrgStats := make(chan m.OrgStats, len(p.Report.Orgs))
 
-	go report.Orgs.Stats(chOrgStats)
+	go p.Report.Orgs.Stats(chOrgStats)
 	for orgStats := range chOrgStats {
 
-		chSpaceStats := make(chan SpaceStats, len(orgStats.Spaces))
+		chSpaceStats := make(chan m.SpaceStats, len(orgStats.Spaces))
 
 		// TODO dynamic filtering?
 		go orgStats.Spaces.Stats(chSpaceStats, orgStats.Name == "p-spring-cloud-services")


### PR DESCRIPTION
closes https://github.com/aegershman/cf-trueup-plugin/issues/24
closes https://github.com/aegershman/cf-trueup-plugin/issues/34

moves 'presenters' into their own package to allow different rendering techniques... Very much a WIP.

Needs a lot of love and care but it's just laying the groundwork for it

references:
- https://github.com/olekukonko/tablewriter
- https://github.com/pivotal-cf/om/blob/80558c89785d3120c4e767ba604a0d498bed135f/presenters/table_presenter.go