### PR TITLE
invert specifying format to a flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,9 +43,10 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 				Name:     "trueup-view",
 				HelpText: "View AIs, SIs and memory usage for orgs and spaces",
 				UsageDetails: plugin.Usage{
-					Usage: "cf trueup-view [-o orgName]",
+					Usage: "cf trueup-view [-o orgName...] --format string",
 					Options: map[string]string{
-						"o": "organization to include in report. flag can be provided multiple times.",
+						"-o":       "organization(s) included in report. Flag can be provided multiple times.",
+						"--format": "format to print as (options: string,table) (default: string)",
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -43,10 +43,10 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 				Name:     "trueup-view",
 				HelpText: "View AIs, SIs and memory usage for orgs and spaces",
 				UsageDetails: plugin.Usage{
-					Usage: "cf trueup-view [-o orgName...] --format string",
+					Usage: "cf trueup-view [-o orgName...] -f string",
 					Options: map[string]string{
-						"-o":       "organization(s) included in report. Flag can be provided multiple times.",
-						"--format": "format to print as (options: string,table) (default: string)",
+						"-o": "organization(s) included in report. Flag can be provided multiple times.",
+						"-f": "format to print as (options: string,table) (default: string)",
 					},
 				},
 			},
@@ -57,8 +57,11 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 // UsageReportCommand -
 func (cmd *UsageReportCmd) UsageReportCommand(args []string) {
 	var userFlags flags
+	var formatFlag string
+
 	flagss := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flagss.Var(&userFlags, "o", "-o orgName")
+	flagss.StringVar(&formatFlag, "f", "string", "")
 	err := flagss.Parse(args[1:])
 	if err != nil {
 		fmt.Println(err)
@@ -87,8 +90,8 @@ func (cmd *UsageReportCmd) UsageReportCommand(args []string) {
 
 	report.Orgs = orgs
 
-	presenter := p.NewPresenter(report)
-	presenter.AsString()
+	presenter := p.NewPresenter(report, formatFlag)
+	presenter.Render()
 }
 
 func (cmd *UsageReportCmd) getOrgs() ([]models.Org, error) {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 2,
 			Minor: 7,
-			Build: 2,
+			Build: 3,
 		},
 		Commands: []plugin.Command{
 			{

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -7,11 +7,29 @@ import (
 // Presenter -
 type Presenter struct {
 	Report m.Report
+	Format string
 }
 
 // NewPresenter -
-func NewPresenter(r m.Report) Presenter {
+func NewPresenter(r m.Report, format string) Presenter {
 	return Presenter{
 		Report: r,
+		Format: format,
+	}
+}
+
+// Render -
+func (p *Presenter) Render() {
+	switch p.Format {
+	case "string":
+		p.AsString()
+	case "table":
+		p.AsTable()
+	default:
+		// TODO
+		// yeah this is kind of awful I know, I'm sorry, I'm still learning,
+		// I'll fix this along with much better and earlier error handling on this
+		// I'll fix this, I promise
+		p.AsString()
 	}
 }

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -22,14 +22,14 @@ func NewPresenter(r m.Report, format string) Presenter {
 func (p *Presenter) Render() {
 	switch p.Format {
 	case "string":
-		p.AsString()
+		p.asString()
 	case "table":
-		p.AsTable()
+		p.asTable()
 	default:
 		// TODO
 		// yeah this is kind of awful I know, I'm sorry, I'm still learning,
 		// I'll fix this along with much better and earlier error handling on this
 		// I'll fix this, I promise
-		p.AsString()
+		p.asString()
 	}
 }

--- a/presenters/stringPresenter.go
+++ b/presenters/stringPresenter.go
@@ -7,8 +7,7 @@ import (
 	m "github.com/aegershman/cf-trueup-plugin/models"
 )
 
-// AsString -
-func (p *Presenter) AsString() {
+func (p *Presenter) asString() {
 	var response bytes.Buffer
 
 	totalApps := 0

--- a/presenters/tablePresenter.go
+++ b/presenters/tablePresenter.go
@@ -8,8 +8,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-// AsTable -
-func (p *Presenter) AsTable() {
+func (p *Presenter) asTable() {
 
 	chOrgStats := make(chan m.OrgStats, len(p.Report.Orgs))
 


### PR DESCRIPTION
see: 
- https://github.com/aegershman/cf-trueup-plugin/issues/34
- https://github.com/aegershman/cf-trueup-plugin/issues/24

This definitely is ugly as heck and I'm so sorry for it, I'll get to it, but--

allows specifying `--f` for `format` flag to invert control to user for which presenter to use... even though basically all the presenters suck. But the scaffolding is getting closer.